### PR TITLE
What is your take on ImagePackage for collab?

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,7 +4,7 @@ import {
 } from 'substance'
 
 import { SimpleWriter, SimpleWriterPackage } from 'substance-simple-writer/index.es.js'
-import { ImagePackage, PersistencePackage } from 'substance'
+import { ImagePackage } from 'substance'
 
 /*
   Configuration
@@ -39,33 +39,12 @@ let documentClient = new DocumentClient({
   httpUrl: DOCUMENT_SERVER_URL
 })
 
-class SaveHandlerStub {
-  /*
-    Saving a document involves two steps.
-    - syncing files (e.g. images) with a backend
-    - storing a snapshot of the document's content (e.g. a XML serialization)
-  */
-  saveDocument(params) {
-    console.info('Simulating save ...', params)
-
-    return params.fileManager.sync()
-    .then(() => {
-      // Here you would run a converter (HTML/XML) usually
-      // and send the result to a REST endpoint.
-      console.info('Creating document snapshot...')
-    })
-  }
-}
-
 /*
   SimpleWriter configuration
 */
 let cfg = new Configurator()
 cfg.import(SimpleWriterPackage)
 cfg.import(ImagePackage)
-// Enable save button
-cfg.import(PersistencePackage)
-cfg.setSaveHandlerClass(SaveHandlerStub)
 
 window.onload = function() {
   documentClient.getDocument(EXAMPLE_DOCUMENT_ID, function(err, docRecord) {

--- a/app/app.js
+++ b/app/app.js
@@ -4,6 +4,7 @@ import {
 } from 'substance'
 
 import { SimpleWriter, SimpleWriterPackage } from 'substance-simple-writer/index.es.js'
+import { ImagePackage, PersistencePackage } from 'substance'
 
 /*
   Configuration
@@ -38,11 +39,33 @@ let documentClient = new DocumentClient({
   httpUrl: DOCUMENT_SERVER_URL
 })
 
+class SaveHandlerStub {
+  /*
+    Saving a document involves two steps.
+    - syncing files (e.g. images) with a backend
+    - storing a snapshot of the document's content (e.g. a XML serialization)
+  */
+  saveDocument(params) {
+    console.info('Simulating save ...', params)
+
+    return params.fileManager.sync()
+    .then(() => {
+      // Here you would run a converter (HTML/XML) usually
+      // and send the result to a REST endpoint.
+      console.info('Creating document snapshot...')
+    })
+  }
+}
+
 /*
   SimpleWriter configuration
 */
 let cfg = new Configurator()
 cfg.import(SimpleWriterPackage)
+cfg.import(ImagePackage)
+// Enable save button
+cfg.import(PersistencePackage)
+cfg.setSaveHandlerClass(SaveHandlerStub)
 
 window.onload = function() {
   documentClient.getDocument(EXAMPLE_DOCUMENT_ID, function(err, docRecord) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "substance-collab-writer",
   "description": "Reference implementation for a collaborative editor",
   "dependencies": {
-    "substance": "1.0.0-beta.6.2",
+    "substance": "1.0.0-beta.6.5",
     "substance-simple-writer": "1.0.0-beta.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, when an image is added through file selection, other clients get an immediate error with `URL.createObjectURL`. I'm assuming it would be a bad idea to try to send serialized images over the websockets connection, as they can be very large.

With a FileProxy in place the image node would still be distributed before there is time to upload and produce a real external URL.

Is there already a mechanism for images in collab? If not, how would you suggest this is done?